### PR TITLE
Aagc2 54 add chatid to return value

### DIFF
--- a/app/core/llm/chain/chatchain.py
+++ b/app/core/llm/chain/chatchain.py
@@ -61,4 +61,10 @@ Please provide a helpful and relevant response.""",
             "model_name": inputs.model_name or "gemini-pro",
         }
 
-        return self.chain.invoke(formatted_input, **kwargs)
+        # Get result from the chain
+        result = self.chain.invoke(formatted_input, **kwargs)
+
+        # Add chat_id to result
+        result.chat_id = inputs.chat_id
+
+        return result

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -27,3 +27,4 @@ class ChatOutput(BaseOutput):
 
     role: str = Field(..., description="Role of the response")
     response: str = Field(..., description="Response content")
+    chat_id: str = Field(..., description="Unique identifier for the chat session")

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -19,7 +19,7 @@ class ChatInput(BaseInput):
     response: str = Field(..., description="Current message content")
     history: List[ChatMessage] = Field(default=[], description="Chat history")
     model_name: Optional[str] = Field(default=None, description="Model deployment name")
-    chat_id: str = Field(..., description="Unique identifier for the chat session")
+    chat_id: Optional[str] = Field(default=None, description="Unique identifier for the chat session")
 
 
 class ChatOutput(BaseOutput):

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from typing import Optional
 
-from app.core.llm.chain import BaseChain
+from app.core.llm.chain.base import BaseChain
 from app.repositories.chat_history_repository import ChatHistoryRepository
 from app.schemas.chat import ChatInput, ChatMessage, ChatOutput
 

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -52,6 +52,9 @@ class ChatService:
             # Invoke the chain directly with ChatInput
             result = self.chain.invoke(chat_input)
 
+            # Add chat_id to the result
+            result.chat_id = chat_input.chat_id
+
             # Save assistant's response to history if repository is available
             if self.chat_history_repository:
                 assistant_message = ChatMessage(role=result.role, content=result.response)
@@ -62,4 +65,6 @@ class ChatService:
         except Exception as e:
             logger.error(f"Error in chat service: {str(e)}")
             # Return error response
-            return ChatOutput(role="assistant", response=f"Sorry, I encountered an error: {str(e)}")
+            return ChatOutput(
+                role="assistant", response=f"Sorry, I encountered an error: {str(e)}", chat_id=chat_input.chat_id
+            )


### PR DESCRIPTION
## 概要
ChatOutputにchat_idフィールドを追加し、レスポンスと共にチャットIDを返すように修正

## 詳細
- ChatOutputスキーマにchat_idフィールドを追加
- ChatServiceでエラー時にもchat_idを返却するよう修正
- ChatChainでレスポンスにchat_idを設定するよう修正

## 確認したこと
- 全てのチャットレスポンスでchat_idが返却されることを確認
以下はレスポンス例
```json
{
  "role": "assistant",
  "response": "I am doing well, thank you for asking! How can I help you today?",
  "chat_id": "test-chat-123"
}
```

## 確認してほしいこと
- ChatChainとChatServiceの両方でchat_idを設定している重複が適切か
- すべてのチャットフローでchat_idが適切に伝播しているか